### PR TITLE
Return false in node instead of throwing an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # is-opera-mini
 
-Client-side detection of Opera Mini versions with limited JavaScript support using the official method [documented on Opera’s blog](https://dev.opera.com/articles/view/opera-mini-and-javascript/#detectingmini).
+Detect Opera Mini versions with limited JavaScript support using the official method [documented on Opera’s blog](https://dev.opera.com/articles/view/opera-mini-and-javascript/#detectingmini).
 
 ### Installation
 

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 "use strict";
-module.exports = window && Object.prototype.toString.call(window.operamini) === "[object OperaMini]";
+module.exports = typeof window !== "undefined" && Object.prototype.toString.call(window.operamini) === "[object OperaMini]";


### PR DESCRIPTION
This makes the module safe to require + execute in node by returning `false` instead of throwing an error on `window`. I stole the technique from [this SO answer](http://stackoverflow.com/a/4224668/349353).

Before:

```
$ node
> var isOperaMini = require('is-opera-mini');
ReferenceError: window is not defined
    at Object.<anonymous> ([...]/node_modules/is-opera-mini/index.js:2:18)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at repl:1:19
    at REPLServer.defaultEval (repl.js:248:27)
    at bound (domain.js:287:14)
```

After:

```
$ node
> var isOperaMini = require('is-opera-mini');
undefined
> console.log(isOperaMini);
false
```

Tested on node v0.12.7 and v5.4.1.

Was also a good excuse to fire up the old [Opera Mini emulator](https://dev.opera.com/articles/installing-opera-mini-on-your-computer/)... :relaxed: 

![screen shot 2016-01-19 at 13 55 53](https://cloud.githubusercontent.com/assets/352105/12419644/b897ae1c-beb7-11e5-9a61-9844724acad4.png)

(I'll leave the test page up for now: http://peterjmags.com/omt/)
